### PR TITLE
Add PropType.string for defaultSize to allow "xx%"

### DIFF
--- a/src/SplitPane.js
+++ b/src/SplitPane.js
@@ -200,7 +200,7 @@ SplitPane.propTypes = {
   primary: PropTypes.oneOf(['first', 'second']),
   minSize: PropTypes.number,
   maxSize: PropTypes.number,
-  defaultSize: PropTypes.number,
+  defaultSize: PropTypes.oneOfType([PropTypes.number, PropTypes.string)],
   size: PropTypes.oneOfType([PropTypes.number, PropTypes.string]),
   allowResize: PropTypes.bool,
   split: PropTypes.oneOf(['vertical', 'horizontal']),


### PR DESCRIPTION
This allows us to easily set the width of the panes to any portion of a container.
(which is already possible but now it won't throw an error)
